### PR TITLE
chore: upgrade to @graphql-markdown/docusaurus v1.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-classic": "^3.10.0",
         "@docusaurus/theme-search-algolia": "^3.10.0",
-        "@graphql-markdown/docusaurus": "^1.34.0",
+        "@graphql-markdown/docusaurus": "^1.35.0",
         "@graphql-tools/url-loader": "^9.1.1",
         "@mdx-js/react": "^3.1.1",
         "graphql": "^16.13.2",
@@ -4096,22 +4096,6 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/utils/node_modules/p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@envelop/core": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.5.1.tgz",
@@ -4185,15 +4169,14 @@
       }
     },
     "node_modules/@graphql-markdown/cli": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/cli/-/cli-0.7.1.tgz",
-      "integrity": "sha512-cU3Y7jbVcI3kxo6HJm4oaEFTgSUzkfxt3IK4StbD5xySCrivb7MEJbnHoPDorW7gR8r1CXfbwXpHRWum4Cfr1g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/cli/-/cli-1.0.0.tgz",
+      "integrity": "sha512-DBJZdKUOpr1koCkPXLfzhaIazGeUVu471PF4Wjz9Rx3nhMwx4EmGUZrKQ4uOk16p9Gdyk6aortKA50WrXK2LMA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.20.0",
-        "@graphql-markdown/logger": "^1.0.6",
-        "@graphql-markdown/printer-legacy": "^1.15.0",
-        "@graphql-markdown/types": "^1.12.0",
+        "@graphql-markdown/core": "^1.21.0",
+        "@graphql-markdown/logger": "^1.0.7",
+        "@graphql-markdown/types": "^1.13.0",
         "commander": "^5.1.0",
         "graphql-config": "5.1.6"
       },
@@ -4205,24 +4188,24 @@
       }
     },
     "node_modules/@graphql-markdown/core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/core/-/core-1.20.0.tgz",
-      "integrity": "sha512-iy1dIzwa1RSZUwrzvWGcX3K9inZOQNF8H3jRMxkFoqhXOSAr8pX5D3C/Fhy+q8k/hI6cICpY2d9Pt/c4ErCYmg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-Ak2Dkrw5oqPicR5aV54ba4FilS25yS24X4lSzypczkPYcjUaab4VJK5Wxixd4rZ9/mKai6wmTYuXqKa2CuBoUw==",
       "license": "MIT",
       "dependencies": {
         "@fastify/deepmerge": "^3.2.1",
-        "@graphql-markdown/graphql": "^1.2.1",
-        "@graphql-markdown/logger": "^1.0.6",
-        "@graphql-markdown/types": "^1.12.0",
-        "@graphql-markdown/utils": "^1.11.0"
+        "@graphql-markdown/graphql": "^1.2.2",
+        "@graphql-markdown/logger": "^1.0.7",
+        "@graphql-markdown/printer-legacy": "^1.16.0",
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.1.14",
-        "@graphql-markdown/helpers": "^1.0.13",
-        "@graphql-markdown/printer-legacy": "^1.15.0",
+        "@graphql-markdown/diff": "^1.1.15",
+        "@graphql-markdown/helpers": "^1.1.0",
         "graphql-config": "5.1.6"
       },
       "peerDependenciesMeta": {
@@ -4232,25 +4215,23 @@
         "@graphql-markdown/helpers": {
           "optional": true
         },
-        "@graphql-markdown/printer-legacy": {
-          "optional": true
-        },
         "graphql-config": {
           "optional": true
         }
       }
     },
     "node_modules/@graphql-markdown/docusaurus": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/docusaurus/-/docusaurus-1.34.0.tgz",
-      "integrity": "sha512-Rn1AfQStpBSBHn5a+Y6pJ7ZzdlajSm9ZjWc8iOP4Ps8us41nrcZadZKEO3HZAgGowgnwomACVCbBqzqCM32d1Q==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/docusaurus/-/docusaurus-1.35.0.tgz",
+      "integrity": "sha512-9CbvFuf4/7cR+9wWsiz8y0iV58hwAkDm0Sv4vz3GcTABfxmJhll/WwhmD0fXbBRXi8v0TmrdrzKkKSKxmVsgAg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/utils": ">=3.9.2",
-        "@graphql-markdown/cli": "^0.7.1",
-        "@graphql-markdown/logger": "^1.0.6",
-        "@graphql-markdown/types": "^1.12.0",
-        "@graphql-markdown/utils": "^1.11.0"
+        "@docusaurus/utils": "3.10.1",
+        "@graphql-markdown/cli": "^1.0.0",
+        "@graphql-markdown/formatters": "^1.0.0",
+        "@graphql-markdown/logger": "^1.0.7",
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0"
       },
       "engines": {
         "node": ">=20"
@@ -4259,68 +4240,194 @@
         "@docusaurus/logger": "*"
       }
     },
-    "node_modules/@graphql-markdown/graphql": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/graphql/-/graphql-1.2.1.tgz",
-      "integrity": "sha512-e6lIjZoJLY2jzFaSe9zjfqFNWrcS+IoSU9OHUUdZ9GPJcvbBozJBgEYCv7+Ve+EWQVFVRv5NEXBpU1ZAaGR87A==",
+    "node_modules/@graphql-markdown/docusaurus/node_modules/@docusaurus/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/types": "^1.12.0",
-        "@graphql-markdown/utils": "^1.11.0",
-        "@graphql-tools/load": "8.1.8"
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@graphql-markdown/docusaurus/node_modules/@docusaurus/utils": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "escape-string-regexp": "^4.0.0",
+        "execa": "^5.1.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "github-slugger": "^1.5.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "jiti": "^1.20.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "p-queue": "^6.6.2",
+        "prompts": "^2.4.2",
+        "resolve-pathname": "^3.0.0",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@graphql-markdown/docusaurus/node_modules/@docusaurus/utils-common": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@graphql-markdown/docusaurus/node_modules/@docusaurus/utils/node_modules/@docusaurus/logger": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@graphql-markdown/docusaurus/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@graphql-markdown/formatters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/formatters/-/formatters-1.0.0.tgz",
+      "integrity": "sha512-EJgY9tglvAHn/SdG/0mJBPmOcmC07e9ZpLK7EFEYkznEFD2QtorxlvOtGVf+/0U6Hkqh1+hccflnccNteNPwpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-markdown/helpers": "^1.1.0",
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@graphql-markdown/graphql": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/graphql/-/graphql-1.2.2.tgz",
+      "integrity": "sha512-v4W8ijA3myjZ/j0Vilryyc+fkC9ir92mmVyAxbYqO81elldtY3+Gcq1C98b+SMjXkiPXvPNdOQksULsRfLniGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0",
+        "@graphql-tools/load": "8.1.10"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": "16.13.2"
+        "graphql": "16.14.0"
+      }
+    },
+    "node_modules/@graphql-markdown/helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/helpers/-/helpers-1.1.0.tgz",
+      "integrity": "sha512-7eJS7Y0KBO5LTocDrAMV9yMvI23Ui0YefMYueUwxzHW31ItOQ8uLlMPgazi2SHD8CpcEaZIZpmchQUFiAlsToQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-markdown/graphql": "^1.2.2",
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "graphql": "16.14.0"
       }
     },
     "node_modules/@graphql-markdown/logger": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/logger/-/logger-1.0.6.tgz",
-      "integrity": "sha512-zRvmYoTNSvYfsyzz7axZVM64n/68Zwpb6z9RBNfTALuLAetY8z/MDm1dM+hGNWurd4a4LVDXTvwj+8QV100tYg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-VsdD/1nQAqX1OW2ggsCILChbULg3931aAwWYfNz176PgkM1/H4p2SyY9R+xRy1c27V6YGrrwZVuNsC6H4Ze2ng==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/types": "^1.12.0"
+        "@graphql-markdown/types": "^1.13.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@graphql-markdown/printer-legacy": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/printer-legacy/-/printer-legacy-1.15.0.tgz",
-      "integrity": "sha512-MEkT+eqD83R2Azarjf8HzdF0RoFrGejX2hDsEsyplAQQdvYcnoN7TtpwYt8aYoMFy2Z8Ck1w4YsC/n65eWNbFQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/printer-legacy/-/printer-legacy-1.16.0.tgz",
+      "integrity": "sha512-lI4caIWUOmJ3FDz9yfa81icOJPZ5OipGht93eylA9+FTE9hYDHHeCklw9MDrk3dtuVJFoJAXwFaNOPKqJ3JY7A==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.2.1",
-        "@graphql-markdown/types": "^1.12.0",
-        "@graphql-markdown/utils": "^1.11.0"
+        "@graphql-markdown/formatters": "^1.0.0",
+        "@graphql-markdown/graphql": "^1.2.2",
+        "@graphql-markdown/types": "^1.13.0",
+        "@graphql-markdown/utils": "^1.12.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@graphql-markdown/types": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/types/-/types-1.12.0.tgz",
-      "integrity": "sha512-QfSRTUpUKSdH6waYaP4B9sIFnBppwW5tEA+wOKNv9F8O4UhAtdLHywy+J+Xvsfp5Oq+jhvbmQe9Frz6YZ3euEg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/types/-/types-1.13.0.tgz",
+      "integrity": "sha512-zZLNtYQg305uNKYOv6cJZJ+9CeHGQPDV40YglGdJmAITGszY1dzI6PYSangUa7cyZne8xQ4alKnrE7xutNdoIQ==",
       "license": "MIT"
     },
     "node_modules/@graphql-markdown/utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@graphql-markdown/utils/-/utils-1.11.0.tgz",
-      "integrity": "sha512-643CKSFK2tSlw5BC12t+NAKSw7pSygFvpCgLbOSl5TOATTRD0HY1NrLjC2Lwiw3f+aJKpwRjtIi+YUwsUu75sQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@graphql-markdown/utils/-/utils-1.12.0.tgz",
+      "integrity": "sha512-ig56D1ltP1wSuD5NueuVPHFhhDkVpAbsSBDTjAX5mVJvZ0oGOBvokbKahWmsLYExpQbH4pFsmfNrvNZ/lmr+dQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/types": "^1.12.0"
+        "@graphql-markdown/types": "^1.13.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "prettier": "3.8.1"
+        "prettier": "3.8.3"
       },
       "peerDependenciesMeta": {
         "prettier": {
@@ -4611,13 +4718,13 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "8.1.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.8.tgz",
-      "integrity": "sha512-gxO662b64qZSToK3N6XUxWG5E6HOUjlg5jEnmGvD4bMtGJ0HwEe/BaVZbBQemCfLkxYjwRIBiVfOY9o0JyjZJg==",
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.10.tgz",
+      "integrity": "sha512-hjcvfEFtwtc8vGi46wtpmGWadNzfEhzbjqinyFIZuIZPlR4aYdWQtqWtY/RMM4Ew4t1USkMNm6xrqC2TH1vCSA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^10.0.31",
-        "@graphql-tools/utils": "^11.0.0",
+        "@graphql-tools/schema": "^10.0.33",
+        "@graphql-tools/utils": "^11.1.0",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
@@ -4628,14 +4735,13 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/load/node_modules/@graphql-tools/schema": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
-      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
+    "node_modules/@graphql-tools/merge": {
+      "version": "9.1.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.9.tgz",
+      "integrity": "sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.1.7",
-        "@graphql-tools/utils": "^11.0.0",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -4645,13 +4751,14 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/merge": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
-      "integrity": "sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==",
+    "node_modules/@graphql-tools/schema": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.33.tgz",
+      "integrity": "sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.0.0",
+        "@graphql-tools/merge": "^9.1.9",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -4709,9 +4816,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.1.tgz",
-      "integrity": "sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -4817,23 +4924,6 @@
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.6",
         "@whatwg-node/promise-helpers": "^1.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/schema": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
-      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^9.1.7",
-        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -9815,9 +9905,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -14092,6 +14182,22 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-classic": "^3.10.0",
     "@docusaurus/theme-search-algolia": "^3.10.0",
-    "@graphql-markdown/docusaurus": "^1.34.0",
+    "@graphql-markdown/docusaurus": "^1.35.0",
     "@graphql-tools/url-loader": "^9.1.1",
     "@mdx-js/react": "^3.1.1",
     "graphql": "^16.13.2",


### PR DESCRIPTION
## Summary

- Bumps `@graphql-markdown/docusaurus` from `^1.34.0` to `^1.35.0`
- v1.35.0 bundles `@graphql-markdown/formatters/docusaurus` internally — no additional formatter configuration needed

## Test plan

- [ ] `npm run doc` generates docs without errors
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)